### PR TITLE
“<uses-sdk” may not exist

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ Then add the following elements code on top of the "application" element:
 
 ~~~xml
 <!-- Permissions and features -->
-<uses-sdk
+
 
     <uses-permission android:name="android.permission.VIBRATE" />
     <uses-permission android:name="android.permission.INTERNET" />
@@ -190,7 +190,7 @@ Finally, once you finish all the configurations for AndroidManifest.xml file, yo
     package="com.dji.importSDKDemo">
 
     <!-- Permissions and features -->
-    <uses-sdk
+    
 
     <uses-permission android:name="android.permission.VIBRATE" />
     <uses-permission android:name="android.permission.INTERNET" />


### PR DESCRIPTION
when “<uses-sdk” exists, the IDE reports error, and in SDKSample's Manifest, there is no “<uses-sdk” here
