### PR TITLE
Update AndroidManifest.xml

### DIFF
--- a/ImportSDKDemo/app/src/main/AndroidManifest.xml
+++ b/ImportSDKDemo/app/src/main/AndroidManifest.xml
@@ -41,6 +41,7 @@
 
         <!-- DJI SDK -->
         <uses-library android:name="com.android.future.usb.accessory" />
+        <uses-library android:name="org.apache.http.legacy" android:required="false" />
         <meta-data
             android:name="com.dji.sdk.API_KEY"
             android:value="Please enter your App Key here." />


### PR DESCRIPTION
In order to get the tutorial to work I had to make the following changes. According to the links below this is the correct approach.

Discussion on the issue:
https://stackoverflow.com/questions/50461881/java-lang-noclassdeffounderrorfailed-resolution-of-lorg-apache-http-protocolve

Proposed approach:
https://developers.google.com/maps/documentation/android-sdk/config#specify_requirement_for_apache_http_legacy_library

> If your app is targeting API level 28 (Android 9.0) or above, you must include the following declaration within the <application> element of AndroidManifest.xml.